### PR TITLE
issue-24 Limit the characters of the title and body of the notes

### DIFF
--- a/frontend/src/pages/Home/AddEditNotes.jsx
+++ b/frontend/src/pages/Home/AddEditNotes.jsx
@@ -9,6 +9,8 @@ const AddEditNotes = ({ noteData, type, getAllNotes, onClose }) => {
     const [content, setContent] = useState('');
     const [tags, setTags] = useState([]);
     const [error, setError] = useState(null);
+    const MAX_TITLE_LENGTH = 60;
+    const MAX_CONTENT_LENGTH = 2500;
 
     useEffect(() => {
         if (type === 'edit' && noteData) {
@@ -17,6 +19,20 @@ const AddEditNotes = ({ noteData, type, getAllNotes, onClose }) => {
             setTags(noteData.tags);
         }
     }, [type, noteData]);
+
+    const handleTitleChange = (e) => {
+        const newTitle = e.target.value;
+        if (newTitle.length <= MAX_TITLE_LENGTH) {
+            setTitle(newTitle);
+        }
+    };
+
+    const handleContentChange = (e) => {
+        const newContent = e.target.value;
+        if (newContent.length <= MAX_CONTENT_LENGTH) {
+            setContent(newContent);
+        }
+    };
 
     const addNewNote = async () => {
         try {
@@ -63,7 +79,7 @@ const AddEditNotes = ({ noteData, type, getAllNotes, onClose }) => {
                 setError("Invalid note data.");
                 return;
             }
-
+            
             console.log(`Updating note with ID: ${noteData._id}`);
 
             const response = await axiosInstance.put(`/edit-note/${noteData._id}`, {
@@ -133,23 +149,33 @@ const AddEditNotes = ({ noteData, type, getAllNotes, onClose }) => {
 
             <div className='flex flex-col gap-2'>
                 <label className='font-medium'>Title</label>
-                <input
-                    type="text"
-                    className='p-2 border rounded-md text-sm'
-                    value={title}
-                    placeholder='Enter note title'
-                    onChange={(e) => setTitle(e.target.value)}
-                />
+                <div className='relative'>
+                    <input
+                        type="text"
+                        className='p-2 border rounded-md text-sm w-full pr-12' // Extra padding to the right
+                        value={title}
+                        placeholder='Enter note title'
+                        onChange={handleTitleChange}
+                    />
+                    <span className='absolute right-2 top-1/2 transform -translate-y-1/2 text-gray-500 text-xs'>
+                        {title.length}/{MAX_TITLE_LENGTH}
+                    </span>
+                </div>
             </div>
 
             <div className='flex flex-col gap-2 mt-4'>
                 <label className='font-medium'>Content</label>
-                <textarea
-                    className='p-2 border rounded-md h-40 text-sm'
-                    placeholder='Enter note content'
-                    value={content}
-                    onChange={(e) => setContent(e.target.value)}
-                ></textarea>
+                <div className='relative'>
+                    <textarea
+                        className='p-2 border rounded-md h-40 text-sm w-full pr-12'
+                        placeholder='Enter note content'
+                        value={content}
+                        onChange={handleContentChange}
+                    ></textarea>
+                    <span className='absolute right-2 bottom-2 text-gray-500 text-xs'>
+                        {content.length}/{MAX_CONTENT_LENGTH}
+                    </span>
+                </div>
             </div>
 
             <div className='flex flex-col gap-2 mt-4'>


### PR DESCRIPTION
## Description

I have recreated the add/update note page, so that the user is now able to put maximum of 60 characters in title and 2500 characters in body. I have also added indicators on how many characters did the user type at the moment.

- Issue #24

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have maintained a clean commit history by using the necessary Git commands
- [X] I have checked that my code does not cause any merge conflicts

![image](https://github.com/user-attachments/assets/4f8f06f7-07d3-4348-bf1d-e041f641b065)
