### PR TITLE
feat : Add Separate Section for Pinned Notes on Notes Page

### DIFF
--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -39,6 +39,7 @@ const Home = () => {
   };
 
   const [allNotes, setAllNotes] = useState([]);
+
   const [userInfo, setUserInfo] = useState(null);
   const [isSearch, setIsSearch] = useState(false);
 
@@ -82,7 +83,7 @@ const Home = () => {
           ...note,
           tags: Array.isArray(note.tags) ? note.tags : [], // Ensure tags is always an array
         }));
-        console.log("Fetched Notes:", notes);
+        // console.log("Fetched Notes:", notes);
         setAllNotes(notes);
       }
     } catch (error) {
@@ -188,6 +189,10 @@ const Home = () => {
     getUserInfo();
   }, []);
 
+  const pinnedNotes = allNotes.filter((note) => note.isPinned === true);
+  const otherNotes = allNotes.filter((note) => note.isPinned !== true);
+  // console.log('pinnedNotes',pinnedNotes)
+  // console.log('otherNotes',otherNotes)
   return (
     <div>
       <Navbar
@@ -209,24 +214,52 @@ const Home = () => {
             })}
           </div>
         ) : allNotes.length > 0 ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4 mt-4 transition-all">
-            {allNotes.map((item) => (
-              <NoteCard
-                key={item._id}
-                title={item.title}
-                date={item.createdOn}
-                content={item.content}
-                tags={item.tags}
-                isPinned={item.isPinned}
-                onEdit={() => handleEdit(item)}
-                onDelete={() => handleDeleteModalOpen(item._id)}
-                onPinNote={() => {
-                  updateIsPinned(item);
-                }}
-                onClick={() => handleViewNote(item)}
-              />
-            ))}
-          </div>
+          <>
+            {pinnedNotes.length > 0 && (
+              <div>
+                <h1 className="font-bold pl-2">PINNED</h1>
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4 mt-2 transition-all mb-3">
+                  {pinnedNotes.map((item) => (
+                    <NoteCard
+                      key={item._id}
+                      title={item.title}
+                      date={item.createdOn}
+                      content={item.content}
+                      tags={item.tags}
+                      isPinned={item.isPinned}
+                      onEdit={() => handleEdit(item)}
+                      onDelete={() => handleDeleteModalOpen(item._id)}
+                      onPinNote={() => {
+                        updateIsPinned(item);
+                      }}
+                      onClick={() => handleViewNote(item)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+            {
+              pinnedNotes.length > 0 && <h1 className="font-bold pl-2">OTHERS</h1>
+            }
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4 mt-2 transition-all">
+              {otherNotes.map((item) => (
+                <NoteCard
+                  key={item._id}
+                  title={item.title}
+                  date={item.createdOn}
+                  content={item.content}
+                  tags={item.tags}
+                  isPinned={item.isPinned}
+                  onEdit={() => handleEdit(item)}
+                  onDelete={() => handleDeleteModalOpen(item._id)}
+                  onPinNote={() => {
+                    updateIsPinned(item);
+                  }}
+                  onClick={() => handleViewNote(item)}
+                />
+              ))}
+            </div>
+          </>
         ) : (
           <EmptyCard
             imgSrc={isSearch ? noFound : addPost}


### PR DESCRIPTION
## Description
This pull request introduces a new feature that displays pinned notes in a separate section on the notes page. Previously, pinned notes were mixed with regular notes, making it harder for users to prioritize important notes. With this update, all pinned notes are shown separately above the regular notes, improving organization and user experience.

- Fixes #84

## Type of change
-add feature

## Key Changes:
- Added a dedicated section at the top of the notes page for displaying pinned notes.
- Styled the pinned notes section to visually differentiate it from the regular notes list.
- Modified the layout to ensure responsiveness and proper alignment across different screen sizes.
- Implemented logic to move notes between the pinned and regular sections when the pin state changes (pinning/unpinning a note).
- If no notes are pinned, the pinned section remains hidden .

## How to Test:
- Create a few notes and pin one or more of them.
- Verify that pinned notes are displayed in the new pinned section above the regular notes.
- Unpin a note and confirm that it moves back to the regular notes section.
- Check the UI for responsiveness and proper layout on different screen sizes.
- Test cases where no notes are pinned to ensure the section behaves correctly.

##Screenshots : 
[Screencast from 2024-10-04 00-38-38.webm](https://github.com/user-attachments/assets/3eafd226-fa5c-4668-9891-998c6878cfe5)

## Additional Notes:
This update enhances the user experience by making important notes more accessible and visually distinct.
Make sure to handle edge cases where there are no pinned notes, or when all pinned notes are unpinned.