### PR TITLE
Fixed the alignment of the empty note section

### DIFF
--- a/frontend/src/components/EmptyCard/EmptyCard.jsx
+++ b/frontend/src/components/EmptyCard/EmptyCard.jsx
@@ -1,15 +1,18 @@
-import React from 'react'
+export default EmptyCard
+
+import React from "react";
 
 const EmptyCard = ({ imgSrc, message }) => {
-    return (
-        <div className='flex flex-col items-center justify-center mt-32'>
-            <img src={imgSrc} alt="Empty Card" className="w-60 h-44" />
+  return (
+    <div className="container h-screen flex items-center justify-center p-6 pb-12">
+      <div className="flex flex-col items-center justify-center">
+        <img src={imgSrc} alt="Empty Card" className="w-60 h-44" />
+        <p className="w-1/2 text-sm font-medium text-slate-700 text-center leading-7 mt-8">
+          {message}
+        </p>
+      </div>
+    </div>
+  );
+};
 
-            <p className='w-1/2 text-sm font-medium text-slate-700 text-center leading-7 mt-8'>
-                {message}
-            </p>
-        </div>
-    )
-}
-
-export default EmptyCard
+export default EmptyCard;

--- a/frontend/src/components/EmptyCard/EmptyCard.jsx
+++ b/frontend/src/components/EmptyCard/EmptyCard.jsx
@@ -1,5 +1,3 @@
-export default EmptyCard
-
 import React from "react";
 
 const EmptyCard = ({ imgSrc, message }) => {


### PR DESCRIPTION
Fixed on searching any random note/note content that does not exist, the image of "Oops! No notes found matching" is slightly at the left side, made it at the centre

- Fixes #25 

