### PR TITLE
Feat: Password hashed

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -198,7 +198,7 @@ app.post("/login", async (req, res) => {
 
   const userInfo = await User.findOne({ email });
 
-  if (!userInfo || await bcrypt.compare(password, userInfo.password)) {
+  if (!userInfo || !(await bcrypt.compare(password, userInfo.password))) {
     return res
       .status(HTTP_STATUS.BAD_REQUEST)
       .json({ message: ERROR_MESSAGES.INVALID_CREDENTIALS });


### PR DESCRIPTION
## Description
Fixes #52 
When we are creating our account then the platform store my password directly but now using bcrypt package when we are creating account then it convert the password into its hashed form not only this when we are login to website then it also compare the current password and hashed password stored in DB using bcrypt.compare(Password, User.password).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have maintained a clean commit history by using the necessary Git commands
- [x] I have checked that my code does not cause any merge conflicts

## Screenshots (if applicable)
Require the module
![bcrypt](https://github.com/user-attachments/assets/d158379b-d1a1-43bb-8211-125c0e6ac1e1)

Signup changes 
- Simply call to bcrypt.hash(password, no_of_times_hashed).
- Use try and catch block for error handling. 
- During creation of user in DB we always store the hashed form of password. 

![SignupChanges](https://github.com/user-attachments/assets/c2cac663-926a-4e38-af7b-919c6e4e9ac6)

Login Changes:
- During validating the password we also check the password is same or not using bcrypt.compare(password, UserInfo.password) if False then not same otherwise proceed to next steps.

![LoginFunctionality](https://github.com/user-attachments/assets/99432d62-3bfe-4a42-85ad-9a48ca85a343)

@yashmandi  Please review my PR and merge it accordingly with the label:)