### PR TITLE
Add Bulk Delete Functionality for Notes

### DIFF
--- a/backend/Routes/Router.js
+++ b/backend/Routes/Router.js
@@ -339,7 +339,7 @@ router.put("/edit-note/:noteId", authenticationToken, async (req, res) => {
 router.put("/update-notes-background", authenticationToken, async (req, res) => {
     const { noteIds, background } = req.body;
     const { user } = req.user;
-  console.log(noteIds)
+//   console.log(noteIds)
     if (!noteIds || !Array.isArray(noteIds) || noteIds.length === 0 || !background) {
       return res.status(HTTP_STATUS.BAD_REQUEST).json({
         error: true,
@@ -366,7 +366,7 @@ router.put("/update-notes-background", authenticationToken, async (req, res) => 
         modifiedCount: notes.modifiedCount,
       });
     } catch (error) {
-      console.error("Error updating notes: ", error);
+    //   console.error("Error updating notes: ", error);
       return res
         .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
         .json({ error: true, message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR });
@@ -419,6 +419,49 @@ router.delete("/delete-note/:noteId", authenticationToken, async (req, res) => {
     }
 });
 
+// delete selected notes
+router.delete("/delete-multiple-notes", authenticationToken, async (req, res) => {
+    const { noteIds } = req.body; // Extract the noteIds from the body
+    const { user } = req.user;
+  
+    // Validate that noteIds is a non-empty array
+    if (!noteIds || !Array.isArray(noteIds) || noteIds.length === 0) {
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
+        error: true,
+        message: ERROR_MESSAGES.PROVIDE_FIELD_TO_UPDATE, // Custom error message
+      });
+    }
+  
+    try {
+      // Delete the notes that belong to the authenticated user and match the IDs
+      const result = await Note.deleteMany({
+        _id: { $in: noteIds }, 
+        userId: user._id, // Ensure notes belong to the authenticated user
+      });
+  
+      // Handle case when no notes were deleted
+      if (result.deletedCount === 0) {
+        return res.status(HTTP_STATUS.NOT_FOUND).json({
+          error: true,
+          message: ERROR_MESSAGES.NOTES_NOT_FOUND,
+        });
+      }
+  
+      // Return success response
+      return res.json({
+        error: false,
+        message: MESSAGES.NOTES_DELETED_SUCCESSFULLY,
+        deletedCount: result.deletedCount, // Return number of deleted notes
+      });
+    } catch (error) {
+      console.error("Error deleting notes:", error);
+      return res
+        .status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+        .json({ error: true, message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR });
+    }
+  });
+  
+  
 // delete user and its notes
 router.delete("/delete-user", authenticationToken, async (req, res) => {
     try {

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -196,7 +196,7 @@ const Home = () => {
   }, []);
 
   const handleNoteSelection = (noteId) => {
-    console.log(noteId)
+    // console.log(noteId)
     setSelectedNotes(prevSelected => {
       if (prevSelected.includes(noteId)) {
         return prevSelected.filter(id => id !== noteId);
@@ -206,7 +206,26 @@ const Home = () => {
     });
   };
 
- 
+  const handleBulkDelete = async () => {
+    try {
+      // Send selected note IDs via the data field, since Axios delete doesn't send req.body directly
+      await axiosInstance({
+        method: 'delete',
+        url: '/delete-multiple-notes',
+        data: { noteIds: selectedNotes }, // Pass the noteIds in the data field
+      });
+  
+      // After successful deletion, refresh the notes and reset selected notes
+      getAllNotes();
+      setSelectedNotes([]);
+      toast.success("Deleted Notes successfully");
+    } catch (error) {
+      console.error("Error deleting notes:", error);
+      toast.error("Failed to delete selected notes");
+    }
+  };
+  
+
   const handleBulkColor = async (color) => {
     try {
       // console.log(color);
@@ -239,16 +258,16 @@ const Home = () => {
       {selectedNotes.length > 0 ? (
         <div className=" bg-white shadow-md z-50 p-4 flex justify-between items-center">
           <span>{selectedNotes.length} notes selected</span>
-          <div className="flex items-center ">
-          <div className="relative  ">
+          <div className="flex items-center gap-x-5">
+          <div className="relative  flex ">
               <button 
                 onClick={() => setIsColorPickerOpen(!isColorPickerOpen)} 
-                className="mr-2"
+                
               >
                 <MdColorLens className="text-2xl" />
               </button>
               {isColorPickerOpen && (
-                <div className="absolute right-0 mt-2 p-2 bg-white  rounded shadow-lg">
+                <div className="absolute top-5 right-0 mt-2 p-2 bg-white  rounded shadow-lg">
                   <input 
                     type="color" 
                     value={background}
@@ -264,7 +283,9 @@ const Home = () => {
                 </div>
               )}
             </div>
-            
+            <button onClick={handleBulkDelete}>
+              <MdDelete className="text-2xl  text-black" />
+            </button>
           </div>
         </div>
       ) : (


### PR DESCRIPTION
## Description
This PR introduces a new feature that allows users to delete multiple notes in a single API call. The bulk delete functionality improves user experience by making it easier and faster to remove multiple notes at once, rather than deleting them individually.
- Fixes #173 

## Type of change
-feature added

## Screen Recording of visual changes : 
[Screencast from 2024-10-14 10-10-10.webm](https://github.com/user-attachments/assets/507bccd4-54b7-47e6-a430-5353af2dd473)


Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Tests update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have maintained a clean commit history by using the necessary Git commands
- [ ] I have checked that my code does not cause any merge conflicts

## Impact:
- Enhances user experience by allowing the deletion of multiple notes at once.
- Optimizes backend API calls by reducing the number of requests needed to delete notes.