### PR TITLE
 [feat]Add Undo Functionality for Deleted Notes

### DIFF
--- a/backend/models/noteModel.js
+++ b/backend/models/noteModel.js
@@ -8,9 +8,14 @@ const noteSchema = new Schema({
     tags: { type: [String], default: [] }, // Ensure this is an array
     attachments:{type:[String],default:[]},
     isPinned: { type: Boolean, required: false },
+    deleted: {
+        type: Boolean,
+        default: false,  // Default is false, meaning the note is not deleted
+      },
     userId: { type: String, required: true },
     createdOn: { type: Date, default: Date.now },
-    background: { type: String }
+    background: { type: String },
+    deletedAt: Date, 
 });
 
 

--- a/frontend/src/pages/Home/Home.jsx
+++ b/frontend/src/pages/Home/Home.jsx
@@ -102,21 +102,22 @@ const Home = () => {
   // delete note
   const deleteNote = async () => {
     try {
+      const deletedNotes = []
       const response = await axiosInstance.delete(
         `/delete-note/${noteToDelete}`
       );
+      if (response.status === 200) {
+        deletedNotes.push(noteToDelete); // Add noteToDelete to the deletedNotes array
+      }
       if (response.data && !response.data.error) {
         getAllNotes();
-        toast.success("Note deleted successfully", {
-          style: {
-            fontSize: "13px",
-            maxWidth: "400px",
-            boxShadow: "px 4px 8px rgba(0, 1, 4, 0.1)",
-            borderRadius: "8px",
-            borderColor: "rgba(0, 0, 0, 0.8)",
-            marginRight: "10px",
-          },
-        });
+        
+        toast.success(
+          <div>
+            Notes deleted. <button className='bg-green-500 p-2 text-white rounded' onClick={() => undoDelete(deletedNotes)}>Undo</button>
+          </div>,
+          { autoClose: 5000 } // Automatically close the toast after 5 seconds
+        );
       }
     } catch (error) {
       console.error("Error deleting note:", error);
@@ -208,6 +209,7 @@ const Home = () => {
 
   const handleBulkDelete = async () => {
     try {
+      const deletedNotes = selectedNotes;
       // Send selected note IDs via the data field, since Axios delete doesn't send req.body directly
       await axiosInstance({
         method: 'delete',
@@ -216,12 +218,35 @@ const Home = () => {
       });
   
       // After successful deletion, refresh the notes and reset selected notes
+      toast.success(
+        <div>
+          Notes deleted. <button className='bg-green-500 p-2 text-white rounded' onClick={() => undoDelete(deletedNotes)}>Undo</button>
+        </div>,
+        { autoClose: 5000 } // Automatically close the toast after 5 seconds
+      );
       getAllNotes();
       setSelectedNotes([]);
-      toast.success("Deleted Notes successfully");
+      // toast.success("Deleted Notes successfully");
     } catch (error) {
       console.error("Error deleting notes:", error);
       toast.error("Failed to delete selected notes");
+    }
+  };
+  
+  // undo delete
+  const undoDelete = async (deletedNotes) => {
+    try {
+      // Send a request to restore the deleted notes
+      await axiosInstance.post('/restore-multiple-notes', {
+        noteIds: deletedNotes
+      });
+  
+      // Refresh the notes list
+      getAllNotes();
+      toast.success("Undo successful. Notes restored.");
+    } catch (error) {
+      console.error("Error restoring notes:", error);
+      toast.error("Failed to undo delete");
     }
   };
   


### PR DESCRIPTION
## Description
This PR introduces an "undo" functionality for deleting notes in our application. Instead of permanently removing notes from the database, the notes will be marked as deleted with a deleted flag. Users will have the option to undo the deletion action, restoring the note back to its original state.

- Fixes #179 

## Type of change
- feature added

## Benefits
**Improved User Experience**: Users can easily recover notes if they accidentally delete them, reducing data loss.
**Data Integrity**: By marking notes as deleted instead of removing them, we maintain the integrity of the database and allow for potential future features like viewing deleted notes.

## Screen recording of visual changes :
[Screencast from 2024-10-14 12-39-54.webm](https://github.com/user-attachments/assets/15a77402-9db2-445f-8112-f81adbffa608)


Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Tests update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have maintained a clean commit history by using the necessary Git commands
- [ ] I have checked that my code does not cause any merge conflicts

