### PR TITLE
Add background color feature for multiple archived notes

### DIFF
--- a/frontend/src/components/ArchivedNotes/ArchivedNotes.jsx
+++ b/frontend/src/components/ArchivedNotes/ArchivedNotes.jsx
@@ -98,6 +98,7 @@ import Navbar from '../Navbar';
 import axiosInstance from '../../utils/axiosInstance';
 import NoteCard from '../Cards/NoteCard';
 import {
+  MdColorLens,
     MdOutlineUnarchive,
 } from "react-icons/md";
 import toast from "react-hot-toast";
@@ -109,6 +110,8 @@ const ArchivedNotes = () => {
   const [selectedNotes, setSelectedNotes] = useState([]);
   const [allNotes, setAllNotes] = useState([]);
   const [refreshNotes, setRefreshNotes] = useState(false); // State to trigger refresh
+  const [background, setBackground] = useState("#ffffff");
+  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
 
   const getArchivedNotes = async () => {
     setIsLoading(true);
@@ -178,12 +181,59 @@ const ArchivedNotes = () => {
     }
   };
 
+  const handleBulkColor = async (color) => {
+    try {
+      // console.log(color);
+      // Send an array of selected note IDs and the new background color in one request
+      await axiosInstance.put('/update-notes-background', {
+        noteIds: selectedNotes,
+        background: color,
+      });
+
+      getArchivedNotes();
+      setSelectedNotes([]);
+      toast.success("Color applied to selected notes");
+    } catch (error) {
+      console.error("Error applying color:", error);
+      toast.error("Failed to apply color to selected notes");
+    }
+  };
+
+  const handleColorChange = (e) => {
+    setBackground(e.target.value);
+  };
+
   return (
     <div>
     {selectedNotes.length > 0 ? (
         <div className=" bg-white shadow-md z-50 p-4 flex justify-between items-center">
           <span>{selectedNotes.length} notes selected</span>
           <div className="flex items-center gap-x-5">
+          <div className="relative  flex ">
+              <button
+                onClick={() => setIsColorPickerOpen(!isColorPickerOpen)}
+
+              >
+                <MdColorLens className="text-2xl" />
+              </button>
+              {isColorPickerOpen && (
+                <div className="absolute top-5 right-0 mt-2 p-2 bg-white  rounded shadow-lg">
+                  <input
+                    type="color"
+                    value={background}
+                    onChange={handleColorChange}
+                    className="w-8 h-8 border-none"
+                  />
+                  <button
+                    onClick={()=>handleBulkColor(background)}
+                    className="ml-2 px-2 py-1 bg-blue-500 text-white rounded text-sm"
+                  >
+                    Apply
+                  </button>
+                </div>
+              )}
+            </div>
+
             <button onClick={handleBulkUnArchive}>
                 <MdOutlineUnarchive className="text-2xl text-black"/>
             </button>


### PR DESCRIPTION
## Description
This PR introduces a feature that allows users to add background color to multiple archived notes. The update enhances the visual distinction between active and archived notes, improving user experience by making archived notes more easily identifiable.

- Fixes #261 

## Type of change
-feature request

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have maintained a clean commit history by using the necessary Git commands
- [ ] I have checked that my code does not cause any merge conflicts

## Screenshots (if applicable)
[Screencast from 2024-10-23 14-50-28.webm](https://github.com/user-attachments/assets/961acacb-5666-4de6-bf0f-8671f5a8caf5)
